### PR TITLE
Fix deleteTweetWithWrongIdTest, add assertFailsWith

### DIFF
--- a/src/test/kotlin/org/unq/ui/model/TwitterSystemTest.kt
+++ b/src/test/kotlin/org/unq/ui/model/TwitterSystemTest.kt
@@ -172,7 +172,12 @@ class TwitterSystemTest {
     fun deleteTweetWithWrongIdTest() {
         val instagramSystem = getTwitterSystemWithTwoUsersAndOneTweetPerUser()
         assertEquals(instagramSystem.tweets.size, 2)
-        instagramSystem.deleteTweet("t_1000")
+        assertFailsWith<NotFound>(
+            message = "No found Tweet",
+            block = {
+                instagramSystem.deleteTweet("t_1000")
+            }
+        )
         assertEquals(instagramSystem.tweets.size, 2)
     }
 


### PR DESCRIPTION
deleteTweetWithWrongIdTest fallaba con la exception No Tweet Found